### PR TITLE
gelf: api for sending log data to gelf storage

### DIFF
--- a/gelf/gelf.go
+++ b/gelf/gelf.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aphistic/golf"
+	"github.com/yext/glog"
+	"github.com/yext/glog-contrib/stacktrace"
+	"github.com/youtube/vitess/go/ratelimiter"
+)
+
+// Capture events and sends them to the gelf server.
+// Events sent at a higher rate than maxEventsPerSec will be ignored.
+// The uri must have a udp or tcp scheme.
+func Capture(attrs map[string]interface{}, serverUri string, maxEventsPerSec int, eventCh <-chan glog.Event) error {
+	c, _ := golf.NewClient()
+	defer c.Close()
+
+	if err := c.Dial(serverUri); err != nil {
+		return err
+	}
+	logger, err := c.NewLogger()
+	if err != nil {
+		return err
+	}
+
+	for k, v := range attrs {
+		logger.SetAttr(k, v)
+	}
+
+	rl := ratelimiter.NewRateLimiter(maxEventsPerSec, time.Second)
+	for e := range eventCh {
+		if !rl.Allow() {
+			continue
+		}
+
+		logEvent(logger, e)
+	}
+	return nil
+}
+
+func logEvent(logger *golf.Logger, e glog.Event) {
+	data := map[string]interface{}{}
+	for _, d := range e.Data {
+		switch t := d.(type) {
+		case map[string]interface{}:
+			for k, v := range t {
+				data[k] = v
+			}
+		}
+	}
+
+	st := stacktrace.Build(e.StackTrace)
+	var frames []string
+	for _, frame := range st.Frames {
+		frames = append(frames, fmt.Sprintf("function %s at line %s", frame.Function, frame.LineNo))
+	}
+	data["exceptionStackTrace"] = strings.Join(frames, ", ")
+
+	message := string(e.Message)
+
+	data["levelName"] = e.Severity
+	switch e.Severity {
+	case "INFO":
+		logger.Infom(data, message)
+	case "WARNING":
+		logger.Warnm(data, message)
+	case "ERROR":
+		logger.Errm(data, message)
+	case "FATAL":
+		logger.Critm(data, message)
+	}
+}

--- a/raven/backend.go
+++ b/raven/backend.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/yext/glog"
+	"github.com/yext/glog-contrib/stacktrace"
 )
 
 var (
@@ -69,7 +70,7 @@ func fromGlogEvent(e glog.Event) *Event {
 		Message:    msg,
 		ServerName: hostname,
 		Extra:      map[string]interface{}{"FullMessage": fullMessage},
-		StackTrace: BuildStackTrace(e.StackTrace),
+		StackTrace: stacktrace.Build(e.StackTrace),
 		Logger:     os.Args[0],
 	}
 
@@ -98,7 +99,7 @@ func fromGlogEvent(e glog.Event) *Event {
 
 // sourceFromStack retrieves the function and line where the
 // event was logged from in the format "file.Function:118".
-func sourceFromStack(s StackTrace) string {
+func sourceFromStack(s stacktrace.StackTrace) string {
 	if len(s.Frames) == 0 {
 		return ""
 	}

--- a/raven/event.go
+++ b/raven/event.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
+
+	"github.com/yext/glog-contrib/stacktrace"
 )
 
 func NewEvent(req *http.Request, message string, depth int) *Event {
@@ -22,7 +24,7 @@ func NewEvent(req *http.Request, message string, depth int) *Event {
 	return &Event{
 		Message:    message,
 		Level:      "ERROR",
-		StackTrace: BuildStackTrace(callers[:written]),
+		StackTrace: stacktrace.Build(callers[:written]),
 		Http:       NewHttp(req),
 	}
 }

--- a/raven/raven.go
+++ b/raven/raven.go
@@ -39,6 +39,7 @@ import (
 	"time"
 
 	"github.com/yext/glog"
+	"github.com/yext/glog-contrib/stacktrace"
 )
 
 type Client struct {
@@ -48,15 +49,6 @@ type Client struct {
 	Project    string
 	httpClient *http.Client
 	Tags       map[string]string
-}
-
-type StackTrace struct {
-	Frames []StackFrame `json:"frames"`
-}
-
-type StackFrame struct {
-	Function string `json:"function"`
-	LineNo   string `json:"lineno"`
 }
 
 type Http struct {
@@ -76,7 +68,7 @@ type Event struct {
 	Level      string                 `json:"level"`
 	Logger     string                 `json:"logger"`
 	ServerName string                 `json:"server_name"`
-	StackTrace StackTrace             `json:"stacktrace"`
+	StackTrace stacktrace.StackTrace  `json:"stacktrace"`
 	Http       *Http                  `json:"request"`
 	Extra      map[string]interface{} `json:"extra"`
 	Tags       map[string]string      `json:"tags"`

--- a/stacktrace/stacktrace.go
+++ b/stacktrace/stacktrace.go
@@ -1,11 +1,20 @@
-package raven
+package stacktrace
 
 import (
 	"runtime"
 	"strconv"
 )
 
-func BuildStackTrace(stack []uintptr) StackTrace {
+type StackTrace struct {
+	Frames []StackFrame `json:"frames"`
+}
+
+type StackFrame struct {
+	Function string `json:"function"`
+	LineNo   string `json:"lineno"`
+}
+
+func Build(stack []uintptr) StackTrace {
 	var ravenStackTrace = make([]StackFrame, len(stack))
 	for i, ptr := range stack {
 		var (


### PR DESCRIPTION
Imported from raven for stack trace parsing. Assuming that's okay.

The code is quite short so unclear if need to factor further e.g.
have a gelf struct and glog->gelf translation.