### PR TITLE
raven: fix CaptureMessagef's formatted print

### DIFF
--- a/raven/raven.go
+++ b/raven/raven.go
@@ -153,7 +153,7 @@ func (client Client) CaptureMessage(message ...string) (result string, err error
 // CaptureMessagef is similar to CaptureMessage except it is using Printf like parameters for
 // formatting the message
 func (client Client) CaptureMessagef(format string, a ...interface{}) (result string, err error) {
-	return client.CaptureMessage(fmt.Sprintf(format, a))
+	return client.CaptureMessage(fmt.Sprintf(format, a...))
 }
 
 func (client Client) CaptureGlogEvent(ev glog.Event) {


### PR DESCRIPTION
Noticed by running `go test`:

    $ go test ./...
    ?   	github.com/yext/glog-contrib/gelf	[no test files]
    # github.com/yext/glog-contrib/raven
    raven/raven.go:156:31: missing ... in args forwarded to printf-like function
    ok  	github.com/yext/glog-contrib/stacktrace	0.608s