### PR TITLE
raven: recognize xerrors, other improvements

### DIFF
--- a/raven/backend.go
+++ b/raven/backend.go
@@ -3,11 +3,14 @@ package raven
 import (
 	"net/http"
 	"os"
+	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/yext/glog"
 	"github.com/yext/glog-contrib/stacktrace"
+	"golang.org/x/xerrors"
 )
 
 var (
@@ -83,34 +86,23 @@ func CaptureErrorsAltDsn(project string, dsns []string, comm <-chan glog.Event) 
 	}
 }
 
-func separateMessageAndIds(message string) (string, string) {
-	msg := re.ReplaceAllString(message, "[ID]")
-	numbers := re.FindAllString(message, -1)
-	ids := strings.Join(numbers, " ")
-	return msg, ids
-}
-
 // fromGlogEvent converts a glog.Event to the format expected by Sentry.
 func fromGlogEvent(e glog.Event) *Event {
 	message := string(e.Message)
-	if square := strings.Index(message, "]"); square != -1 {
-		message = message[square+1:]
+	if square := strings.Index(message, "] "); square != -1 {
+		message = message[square+2:]
 	}
 
-	fullMessage := message
-	if line := strings.Index(message, "\n"); line != -1 {
-		message = message[:line]
-	}
-
-	msg, ids := separateMessageAndIds(message)
-
+	logtrace := stacktrace.Build(e.StackTrace)
 	eve := &Event{
 		Project:    projectName,
 		Level:      strings.ToLower(e.Severity),
-		Message:    msg,
+		Message:    message,
 		ServerName: hostname,
-		Extra:      map[string]interface{}{"FullMessage": fullMessage},
-		StackTrace: stacktrace.Build(e.StackTrace),
+		Extra: map[string]interface{}{
+			"Source": sourceFromStack(logtrace),
+		},
+		StackTrace: logtrace,
 		Logger:     os.Args[0],
 	}
 
@@ -127,15 +119,27 @@ func fromGlogEvent(e glog.Event) *Event {
 			for k, v := range t {
 				data[k] = v
 			}
+		case glog.ErrorArg:
+			// Prepend the Message with the innermost error message.
+			// This causes it to be used for the headline.
+			eve.Message = headline(t.Error) + "\n\n" + message
+
+			// Augment the stack trace of the call site with the stack trace in
+			// the error.
+			eve.StackTrace = getXErrorStackTrace(eve.StackTrace, t.Error)
 		default:
 			//TODO(ltacon): ignore for now...
 		}
 	}
 
-	eve.Extra["Data"] = data
-	eve.Extra["Source"] = sourceFromStack(eve.StackTrace)
-	if ids != "" {
-		eve.Extra["IDs"] = ids
+	// By default, set the fingerprint based on the stack trace.
+	// Sentry is supposed to do that by default, but it does not appear to work.
+	if len(eve.Fingerprint) == 0 {
+		eve.Fingerprint = eve.StackTrace.Strings()
+	}
+
+	if len(data) > 0 {
+		eve.Extra["Data"] = data
 	}
 
 	return eve
@@ -148,6 +152,106 @@ func sourceFromStack(s stacktrace.StackTrace) string {
 		return ""
 	}
 
-	f := s.Frames[0]
+	f := s.Inner()
 	return f.Function + ":" + f.LineNo
+}
+
+// headline returns a good headline for this error.
+// Ideally, it returns a succinct summary that best conveys the error.
+// Most likely, that's something close to the root cause, but that may
+// be something boring like "context canceled".
+func headline(err error) string {
+	// Heuristic: return the error message from the second innermost error.
+	// This provides context on the error, since returned errors are often constants.
+	var prev error
+	for {
+		wrapper, ok := err.(xerrors.Wrapper)
+		if !ok {
+			break
+		}
+		prev = err
+		err = wrapper.Unwrap()
+	}
+	if prev != nil {
+		return prev.Error()
+	}
+	return err.Error()
+}
+
+// getXErrorStackTrace returns a combined stack trace incorporating the stack of
+// the logging call site and that of the error it's logging.
+func getXErrorStackTrace(callSite stacktrace.StackTrace, err error) stacktrace.StackTrace {
+	xs := &xerrorsStack{trace: callSite}
+	for err != nil {
+		xs.detail = false
+		switch xerr := err.(type) {
+		case xerrors.Formatter:
+			err = xerr.FormatError(xs)
+		case xerrors.Wrapper:
+			err = xerr.Unwrap()
+		default:
+			err = nil
+		}
+	}
+	return xs.trace
+}
+
+// xerrorsStack implements xerrors.Printer to capture only the wrapped stack trace.
+//
+// Exploits the fact that xerrors.Frame is always written as detail (and nothing else is, for any
+// known implementation).
+//
+// It expects a sequence of alternating calls like this:
+//
+//   Printf("%s\n    ", []interface {}{"package.FuncName"})
+//   Printf("%s:%d\n", []interface {}{"/absolute/path/to/file.go", 47})
+type xerrorsStack struct {
+	detail bool
+	trace  stacktrace.StackTrace
+	fnName string
+}
+
+func (x *xerrorsStack) Print(args ...interface{}) {}
+
+func (x *xerrorsStack) Printf(format string, args ...interface{}) {
+	if x.detail {
+		switch len(args) {
+		case 1:
+			if fn, ok := args[0].(string); ok {
+				x.fnName = fn
+			}
+		case 2:
+			var (
+				absPath, ok1 = args[0].(string)
+				lineno, ok2  = args[1].(int)
+			)
+			if !ok1 || !ok2 {
+				glog.Warningf("unexpected: Printf(%q, %#v)", format, args)
+				return
+			}
+			x.trace.Frames = append(x.trace.Frames, stacktrace.StackFrame{
+				AbsPath:  absPath,
+				Filename: gopathRelativeFile(absPath),
+				Function: x.fnName,
+				LineNo:   strconv.Itoa(lineno),
+			})
+		}
+	}
+}
+
+func (x *xerrorsStack) Detail() bool {
+	x.detail = true
+	return true
+}
+
+// gopathRelativeFile sanitizes the path to remove GOPATH and obtain the import path.
+// Concretely, this takes the path after the last instance of '/src/'.
+// This may omit some of the path if there is an src directory in a package import path.
+// If there are no /src/ directories in the path, the base filename is returned.
+func gopathRelativeFile(absPath string) string {
+	candidates := strings.SplitAfter(absPath, "/src/")
+	if len(candidates) > 0 {
+		return candidates[len(candidates)-1]
+	}
+	return filepath.Base(absPath)
 }

--- a/stacktrace/stacktrace.go
+++ b/stacktrace/stacktrace.go
@@ -1,6 +1,7 @@
 package stacktrace
 
 import (
+	"fmt"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -51,4 +52,21 @@ func Build(stack []uintptr) StackTrace {
 	}
 
 	return StackTrace{ravenStackTrace}
+}
+
+// Inner returns the innermost stack frame.
+func (st StackTrace) Inner() StackFrame {
+	if len(st.Frames) == 0 {
+		return StackFrame{}
+	}
+	return st.Frames[len(st.Frames)-1]
+}
+
+// Strings returns a list of string descriptions of each stack frame.
+func (st StackTrace) Strings() []string {
+	var r = make([]string, len(st.Frames))
+	for i, f := range st.Frames {
+		r[i] = fmt.Sprintf("%s in %s at line %s", f.Filename, f.Function, f.LineNo)
+	}
+	return r
 }


### PR DESCRIPTION
1. If an error is passed via glog.ErrorArg...
   (a) use the root error's message for the headline
   (b) extend the stack trace using any frames included in the error

2. If not overridden, use a Fingerprint constructed from the stack trace.
   This should cause sentry issues to be properly grouped at long last.
   Sentry is supposed to do this automatically, but it does not seem to happen.

3. Stop replacing strings of digits with [ID]. It makes issues harder to read,
   and it's no longer necessary now that things are grouped by stack trace.

4. Fix the Source extra data to show the log site.
   Previously, it always showed the top frame, e.g. goexit.

5. Remove the extra FullMessage data; Sentry automatically uses the first line
   of the message as the headline, so we can include the full message after a
   newline or two to keep it from cluttering the headline.