### PR TITLE
raven: populate Sentry environment tag

### DIFF
--- a/raven/raven.go
+++ b/raven/raven.go
@@ -125,6 +125,10 @@ func NewClient(dsn string) (client *Client, err error) {
 		m["job_name"] = "unknown"
 	}
 
+	if yextSite := os.Getenv("YEXT_SITE"); yextSite != "" {
+		m["environment"] = yextSite
+	}
+
 	return &Client{
 		URL:       u,
 		PublicKey: publicKey,


### PR DESCRIPTION
We are now using the Environment selector in Sentry, which requires
manually setting the environment tag with this version of raven.

J=SRE-3306
TEST=manual
  Verified with this change that Go services connected to a new
  version of Sentry have data filterable by environment.