### PR TITLE
Migrate from raven to sentry-go package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,39 @@ glog-contrib
 ============
 
 Contributed code for use with the glog package.  For example, logging backends that integrate with other services.
+
+## Sentry
+
+The Sentry package contains an implementation of a bridge between
+the sentry-go package and glog which allows for glog errors of
+level ERROR to be tracked as errors in Sentry. This includes
+custom code that interfaces with the xerrors package (as well
+as the Yext fork named yerrors) in order to send stack trace
+data for the glog invocation, error object construction,
+and any masked error calls to Sentry.
+
+`sentry.CaptureErrors` is the entrypoint for tracking Sentry exceptions via glog.
+Given Sentry DSNs and client options (DSN should not be specified in opts),
+constructs individual Sentry Client's for each DSN. The glog.Event channel
+should be provided by running `glog.RegisterBackend()`. For example:
+
+```go
+sentry.CaptureErrors(
+  "projectName",
+  []string{"https://primaryDsn", "https://optionalSecondaryDsn", ...},
+  sentrygo.ClientOptions{
+    Release: "release",
+    Environment: "prod",
+  },
+  glog.RegisterBackend())
+```
+
+When an event is received via glog at the ERROR severity,
+the first provided DSN will be used, unless a `sentry.AltDsn`
+is tagged on the glog event, in which case the specified client
+for that DSN will be used:
+
+```go
+glog.Error("error for secondary DSN", sentry.AltDsn("https://optionalSecondaryDsn"))
+```
+

--- a/gelf/gelf.go
+++ b/gelf/gelf.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/aphistic/golf"
 	"github.com/yext/glog"
-	"github.com/yext/glog-contrib/stacktrace"
+	"github.com/yext/glog-contrib/raven/stacktrace"
 
 	"golang.org/x/time/rate"
 )
@@ -33,7 +33,7 @@ func Capture(attrs map[string]interface{}, serverUri string, maxEventsPerSec int
 
 	// Also use maxEventsPerSec as the burst size
 	var (
-		limit = rate.Every(time.Second/time.Duration(maxEventsPerSec))
+		limit = rate.Every(time.Second / time.Duration(maxEventsPerSec))
 		rl    = rate.NewLimiter(limit, maxEventsPerSec)
 	)
 	for e := range eventCh {

--- a/raven/backend.go
+++ b/raven/backend.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/yext/glog"
-	"github.com/yext/glog-contrib/stacktrace"
+	"github.com/yext/glog-contrib/raven/stacktrace"
 	"golang.org/x/xerrors"
 )
 

--- a/raven/event.go
+++ b/raven/event.go
@@ -8,7 +8,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/yext/glog-contrib/stacktrace"
+	"github.com/yext/glog-contrib/raven/stacktrace"
 )
 
 func NewEvent(req *http.Request, message string, depth int) *Event {

--- a/raven/raven.go
+++ b/raven/raven.go
@@ -39,7 +39,7 @@ import (
 	"time"
 
 	"github.com/yext/glog"
-	"github.com/yext/glog-contrib/stacktrace"
+	"github.com/yext/glog-contrib/raven/stacktrace"
 )
 
 type Client struct {
@@ -95,6 +95,13 @@ const iso8601 = "2006-01-02T15:04:05"
 // eg:
 //	http://abcd:efgh@sentry.example.com/sentry/project1
 func NewClient(dsn string) (client *Client, err error) {
+	// sentry-go supports a blank DSN as a noop host. Ensure that
+	// if a blank DSN is specified to raven that we treat it like
+	// the default DSN.
+	if dsn == "" {
+		dsn = DefaultSentryDSN
+	}
+
 	u, err := url.Parse(dsn)
 	if err != nil {
 		return nil, err

--- a/raven/stacktrace/stacktrace.go
+++ b/raven/stacktrace/stacktrace.go
@@ -1,0 +1,72 @@
+package stacktrace
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+type StackTrace struct {
+	Frames []StackFrame `json:"frames"`
+}
+
+type StackFrame struct {
+	AbsPath  string `json:"abs_path"`
+	Filename string `json:"filename"`
+	Function string `json:"function"`
+	LineNo   string `json:"lineno"`
+}
+
+func Build(stack []uintptr) StackTrace {
+	var ravenStackTrace = make([]StackFrame, 0, len(stack))
+	frames := runtime.CallersFrames(stack)
+	for {
+		frame, more := frames.Next()
+
+		absPath := frame.File
+		file := filepath.Base(absPath)
+
+		// Sanitize the path to remove GOPATH and obtain the import path.
+		// Will take the path after the last instance of '/src/'.
+		// This may omit some of the path if there is an src directory in a package import path.
+		candidates := strings.SplitAfter(absPath, "/src/")
+		if len(candidates) > 0 {
+			file = candidates[len(candidates)-1]
+		}
+
+		ravenStackTrace = append(ravenStackTrace, StackFrame{
+			AbsPath:  absPath,
+			Filename: file,
+			Function: frame.Function,
+			LineNo:   strconv.Itoa(frame.Line),
+		})
+		if !more {
+			break
+		}
+	}
+	// Reverse the stack trace to fit with Sentry's expectations.
+	for i, j := 0, len(ravenStackTrace)-1; i < j; i, j = i+1, j-1 {
+		ravenStackTrace[i], ravenStackTrace[j] = ravenStackTrace[j], ravenStackTrace[i]
+	}
+
+	return StackTrace{ravenStackTrace}
+}
+
+// Inner returns the innermost stack frame.
+func (st StackTrace) Inner() StackFrame {
+	if len(st.Frames) == 0 {
+		return StackFrame{}
+	}
+	return st.Frames[len(st.Frames)-1]
+}
+
+// Strings returns a list of string descriptions of each stack frame.
+func (st StackTrace) Strings() []string {
+	var r = make([]string, len(st.Frames))
+	for i, f := range st.Frames {
+		r[i] = fmt.Sprintf("%s in %s at line %s", f.Filename, f.Function, f.LineNo)
+	}
+	return r
+}

--- a/raven/stacktrace/stacktrace_test.go
+++ b/raven/stacktrace/stacktrace_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/yext/glog-contrib/stacktrace"
+	"github.com/yext/glog-contrib/raven/stacktrace"
 )
 
 func TestBuild(t *testing.T) {

--- a/sentry/attributes.go
+++ b/sentry/attributes.go
@@ -1,0 +1,21 @@
+package sentry
+
+// Contains attributes which can be passed to glog, which will be used
+// by this package to route and process Sentry errors accordingly.
+
+type altDsn string
+
+// AltDsn can be used as a glog attribute to specify a different DSN for the
+// issue to be sent in Sentry
+func AltDsn(dsn string) interface{} {
+	return altDsn(dsn)
+}
+
+type fingerprint []string
+
+// Fingerprint creates a Sentry fingerprint from a variadic set of strings.
+// This fingerprint will be added to the outgoing event to allow for custom rollup.
+// See: https://docs.sentry.io/learn/rollups/#customize-grouping-with-fingerprints
+func Fingerprint(print ...string) interface{} {
+	return fingerprint(print)
+}

--- a/sentry/backend.go
+++ b/sentry/backend.go
@@ -1,0 +1,226 @@
+// The Sentry package contains an implementation of a bridge between
+// the sentry-go package and glog which allows for glog errors of
+// level ERROR to be tracked as errors in Sentry. This includes
+// custom code that interfaces with the xerrors package (as well
+// as the Yext fork named yerrors) in order to send stack trace
+// data for the glog invocation, error object construction,
+// and any masked error calls to Sentry.
+package sentry
+
+import (
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/yext/glog"
+	"github.com/yext/glog-contrib/stacktrace"
+)
+
+// The maximum number of wrapped errors processed.
+const maxErrorDepth = 10
+
+var (
+	sentryDebug = flag.Bool("sentryDebug", false,
+		"enable debug mode in Sentry clients")
+	sentryFingerprinting = flag.Bool("sentryFingerprinting", false,
+		"enable server-side issue fingerprinting. If set, duplicate issues will only be tracked if they have equivalent filenames and line numbers")
+
+	hostname string
+)
+
+func init() {
+	hostname, _ = os.Hostname()
+	if short := strings.Index(hostname, "."); short != -1 {
+		hostname = hostname[:short]
+	}
+}
+
+// CaptureErrors is the entrypoint for tracking Sentry exceptions via glog.
+// Given Sentry DSNs and client options (DSN should not be specified in opts),
+// constructs individual Sentry Client's for each DSN. The glog.Event channel
+// should be provided by running glog.RegisterBackend(). For example:
+//  sentry.CaptureErrors(
+//  	"projectName",
+//  	[]string{"https://primaryDsn", "https://optionalSecondaryDsn", ...},
+//		sentrygo.ClientOptions{
+//			Release: "release",
+//			Environment: "prod",
+//		},
+//		glog.RegisterBackend())
+//
+// When an event is received via glog at the ERROR severity,
+// the first provided DSN will be used, unless a sentry.AltDsn is
+// tagged on the glog event, in which case the specified client
+// for that DSN will be used:
+//   glog.Error("error for secondary DSN", sentry.AltDsn("https://optionalSecondaryDsn"))
+func CaptureErrors(project string, dsns []string, opts sentry.ClientOptions, comm <-chan glog.Event) {
+	// If no DSNs specified, panic (we can't invoke glog)
+	if len(dsns) == 0 {
+		panic("must specify at least one Sentry DSN")
+	}
+
+	hubs := make(map[string]*sentry.Hub)
+	var primaryHub *sentry.Hub
+	for _, dsn := range dsns {
+		client, err := sentry.NewClient(buildClientOptions(dsn, opts))
+
+		// If unable to initialize the Sentry client, panic (we can't invoke glog)
+		if err != nil {
+			panic(err)
+		}
+
+		// Initialize a Hub (which contains additional scope)
+		scope := sentry.NewScope()
+		hub := sentry.NewHub(client, scope)
+
+		// Set the first provided DSN as the primary hub
+		if primaryHub == nil {
+			primaryHub = hub
+		}
+
+		// Configure the cleanup period for the newly initialized client
+		defer client.Flush(1 * time.Second)
+
+		hubs[dsn] = hub
+	}
+
+	// This for loop runs indefinitely unless the glog channel closes
+	// (which should only happen on app exit)
+	for glogEvent := range comm {
+		if glogEvent.Severity == "ERROR" {
+			e, targetDsn := FromGlogEvent(glogEvent)
+			if hub, ok := hubs[targetDsn]; ok {
+				hub.CaptureEvent(e)
+			} else {
+				primaryHub.CaptureEvent(e)
+			}
+		}
+	}
+}
+
+// Adds the dsn, server hostname, and debug status to the provided client options
+func buildClientOptions(dsn string, opts sentry.ClientOptions) sentry.ClientOptions {
+	opts.Dsn = dsn
+	if !opts.Debug {
+		opts.Debug = *sentryDebug
+	}
+	opts.ServerName = hostname
+
+	return opts
+}
+
+// Builds a fingerprint of the filename, function, and line number for all
+// of the frames in the top (most important) exception stacktrace.
+func buildFingerprint(exceptions []sentry.Exception) []string {
+	var r []string
+	ex := exceptions[0]
+	for _, f := range ex.Stacktrace.Frames {
+		if f.InApp {
+			r = append(r, fmt.Sprintf("%s in %s at line %d", f.Filename, f.Function, f.Lineno))
+		}
+	}
+	return r
+}
+
+// FromGlogEvent processes a glog event and generates a corresponding Sentry event.
+// This includes building the stacktrace, cleaning up the error title and subtitle,
+// and identifying whether any TargetDSN or Fingerprint overrides were set.
+func FromGlogEvent(e glog.Event) (*sentry.Event, string) {
+	targetDsn := ""
+
+	s := sentry.NewEvent()
+	s.Message = removeGlogPrefixFromMessage(e.Message)
+	s.Level = buildLevel(e.Severity)
+	s.ServerName = hostname
+
+	s.Extra = map[string]interface{}{}
+	s.Logger = stacktrace.GopathRelativeFile(os.Args[0])
+
+	data := map[string]interface{}{}
+	for _, d := range e.Data {
+		switch t := d.(type) {
+		case altDsn:
+			targetDsn = string(d.(altDsn))
+		case fingerprint:
+			s.Fingerprint = []string(d.(fingerprint))
+		case *http.Request:
+			s.Request = buildHttpRequest(t)
+		case map[string]interface{}:
+			for k, v := range t {
+				data[k] = v
+			}
+		case glog.ErrorArg:
+			// Prepend the Message with the innermost error message.
+			// This causes it to be used for the headline.
+			hl := headline(t.Error)
+			s.Message = prependMessage(hl, s.Message)
+
+			// Augment the stack trace of the call site with the stack trace in
+			// the error. Loop through and unwrap any chained errors.
+			err := t.Error
+			for i := 0; i < maxErrorDepth && err != nil; i++ {
+				errTrace := stacktrace.ExtractStacktrace(err)
+				s.Exception = append(s.Exception, sentry.Exception{
+					// Type is the primary issue title containing the error string
+					Type: prependMessage(headline(err), err.Error()),
+					// Value is the issue subtitle containing the method name/line
+					Value:      stacktrace.SourceFromStack(errTrace),
+					Stacktrace: errTrace,
+				})
+				switch previous := err.(type) {
+				case interface{ Unwrap() error }:
+					err = previous.Unwrap()
+				case interface{ Cause() error }:
+					err = previous.Cause()
+				default:
+					err = nil
+				}
+			}
+		default:
+			// ignored
+		}
+	}
+
+	// Append the stacktrace provided by glog as the top Exception object,
+	// since it provides information about when glog was invoked in the code
+	trace := stacktrace.ExtractFrames(e.StackTrace, nil)
+	if trace != nil {
+		// Add exception for top-level glog message, if we did not find any
+		// stacktrace data via ErrorArgs
+		s.Exception = append(s.Exception, sentry.Exception{
+			// Type is the primary issue title containing the error string
+			Type: cleanupMessage(s.Message),
+			// Value is the issue subtitle containing the method name/line
+			Value:      stacktrace.SourceFromStack(trace),
+			Stacktrace: trace,
+		})
+	}
+
+	// Reverse the order of the Exception array
+	reverse(s.Exception)
+
+	// Set the fingerprint based on the stack trace, if option is specified.
+	// This overrides logic in Sentry which will take the specific error
+	// message in to account. It instead will be identified by the filename,
+	// method name, and line number.
+	if len(s.Fingerprint) == 0 && *sentryFingerprinting {
+		s.Fingerprint = buildFingerprint(s.Exception)
+	}
+
+	if len(data) > 0 {
+		s.Extra["Data"] = data
+	}
+
+	return s, targetDsn
+}
+
+func reverse(e []sentry.Exception) {
+	for i := len(e)/2 - 1; i >= 0; i-- {
+		o := len(e) - 1 - i
+		e[i], e[o] = e[o], e[i]
+	}
+}

--- a/sentry/backend_test.go
+++ b/sentry/backend_test.go
@@ -1,0 +1,246 @@
+package sentry_test
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"strings"
+	"testing"
+	"time"
+
+	sentrygo "github.com/getsentry/sentry-go"
+	"github.com/yext/glog"
+	"github.com/yext/glog-contrib/sentry"
+	"github.com/yext/yerrors"
+
+	"github.com/kr/pretty"
+)
+
+const pkgName = "github.com/yext/glog-contrib/sentry_test" // this should stay in sync with the location/pkg of the file
+const fileName = "backend_test.go" // this should stay in sync with the name of this file
+
+var sendToDsn = flag.String("sendToDsn", "",
+	"optional sentry DSN. if set, sample exceptions will be sent to Sentry as an integration test")
+
+func setup(ready chan interface{}, done chan *sentrygo.Event, count int) {
+	sentry.CaptureErrors(
+		"example",
+		[]string{*sendToDsn},
+		sentrygo.ClientOptions{Debug: true},
+		wrapper(ready, done, count, glog.RegisterBackend()))
+}
+
+func wrapper(ready chan interface{}, done chan *sentrygo.Event, count int, ch <-chan glog.Event) <-chan glog.Event {
+	ready <- nil
+	i := 0
+	wrap := make(chan glog.Event)
+	go func() {
+		for glogEvent := range ch {
+			pretty.Log("glog event:", glogEvent)
+			if *sendToDsn != "" {
+				wrap <- glogEvent
+				// Give sentry time to process the event.
+				// If removed, on test failure Sentry won't flush its cache
+				time.Sleep(2000 * time.Millisecond)
+			}
+			if glogEvent.Severity == "ERROR" {
+				e, _ := sentry.FromGlogEvent(glogEvent)
+				pretty.Log("Sentry event:", e)
+				done <- e
+				i++
+				if i == count {
+					break
+				}
+			}
+		}
+	}()
+
+	return wrap
+}
+
+func TestGlogSimpleEvent(t *testing.T) {
+	methodName := "TestGlogSimpleEvent" // this should stay in sync with the name of the method
+
+	ready := make(chan interface{})
+	done := make(chan *sentrygo.Event)
+	go setup(ready, done, 1)
+
+	<-ready
+	errorLine := 71 // this should point to the next line
+	glog.Error("test message")
+	e := <-done
+
+	assert.NotNil(t, e)
+	assert.Equal(t, sentrygo.LevelError, e.Level, "level is error")
+	assert.Equal(t, "test message", e.Message, "message matches exactly")
+	assert.Len(t, e.Exception, 1, "one exception")
+
+	ex := e.Exception[0] // the exception is from the glog invocation
+	assert.Equal(t, "test message", ex.Type,
+		"type (primary issue title) matches the error string exactly")
+	assert.True(t, strings.HasPrefix(ex.Value, fmt.Sprintf("%s:%d", methodName, errorLine)),
+		"value (issue subtitle) starts with the method name and error line of the glog invocation: " + ex.Value)
+	assert.NotNil(t, ex.Stacktrace)
+	assert.Len(t, ex.Stacktrace.Frames, 1, "one stacktrace frame")
+
+	fr := ex.Stacktrace.Frames[0]
+	assert.Equal(t, methodName, fr.Function, "function name matches")
+	assert.Equal(t, errorLine, fr.Lineno, "line number matches of the glog invocation")
+	assert.True(t, strings.HasSuffix(fr.AbsPath, fileName), "abspath matches: " + fr.AbsPath)
+	assert.True(t, fr.InApp, "inapp flag true")
+}
+
+func TestGlogRawErrorEvent(t *testing.T) {
+	methodName := "TestGlogRawErrorEvent" // this should stay in sync with the name of the method
+
+	ready := make(chan interface{})
+	done := make(chan *sentrygo.Event)
+	go setup(ready, done, 1)
+
+	<-ready
+	// We cannot track where the raw error occurred because it uses a raw error type
+	err := errors.New("test message")
+	errorLine := 105 // this should point to the next line
+	glog.Error(err)
+	e := <-done
+
+	assert.NotNil(t, e)
+	assert.Equal(t, sentrygo.LevelError, e.Level, "level is error")
+	assert.Equal(t, "test message", e.Message, "message matches exactly")
+	assert.Len(t, e.Exception, 2, "two exceptions (first is from glog, second is from the raw err)")
+
+	ex := e.Exception[0] // the first exception is from the glog invocation
+	assert.Equal(t, "test message", ex.Type,
+		"type (primary issue title) matches the error string exactly")
+	assert.True(t, strings.HasPrefix(ex.Value, fmt.Sprintf("%s:%d", methodName, errorLine)),
+		"value (issue subtitle) starts with the method name and error line of the glog invocation: " + ex.Value)
+	assert.NotNil(t, ex.Stacktrace)
+	assert.Len(t, ex.Stacktrace.Frames, 1, "one stacktrace frame")
+
+	fr := ex.Stacktrace.Frames[0]
+	assert.Equal(t, methodName, fr.Function, "function name matches")
+	assert.Equal(t, errorLine, fr.Lineno, "line number matches of the glog invocation")
+	assert.True(t, strings.HasSuffix(fr.AbsPath, fileName), "abspath matches: " + fr.AbsPath)
+	assert.True(t, fr.InApp, "inapp flag true")
+
+	ex = e.Exception[1] // the second exception is from the raw error
+	assert.Equal(t, "test message", ex.Type,
+		"type (primary issue title) matches the error string exactly")
+	assert.Empty(t, ex.Value, "value of raw error is empty")
+	// the raw error has no stacktrace or stack frames
+	assert.Nil(t, ex.Stacktrace, "stacktrace of raw error is nil")
+}
+
+func TestGlogYerrorsEvent(t *testing.T) {
+	methodName := "TestGlogYerrorsEvent" // this should stay in sync with the name of the method
+
+	ready := make(chan interface{})
+	done := make(chan *sentrygo.Event)
+	go setup(ready, done, 1)
+
+	<-ready
+	errorLine := 144 // this should point to the next line
+	err := yerrors.New("test message")
+	glogErrorLine := errorLine + 2 // this should point to the next line
+	glog.Error(err)
+	e := <-done
+
+	assert.NotNil(t, e)
+	assert.Equal(t, sentrygo.LevelError, e.Level, "level is error")
+	assert.True(t, strings.HasPrefix(e.Message, "test message"),
+		"message starts with the error string")
+	assert.Len(t, e.Exception, 2, "two exceptions (first is from glog, second is from the raw err)")
+
+	ex := e.Exception[0] // first exception is from the glog invocation
+	assert.Equal(t, "test message", ex.Type,
+		"type (primary issue title) matches the error string exactly")
+	assert.True(t, strings.HasPrefix(ex.Value, fmt.Sprintf("%s:%d", methodName, glogErrorLine)),
+		"value (issue subtitle) starts with the method name and error line of the glog invocation: " + ex.Value)
+	assert.NotNil(t, ex.Stacktrace)
+	assert.Len(t, ex.Stacktrace.Frames, 1, "one stacktrace frame")
+
+	fr := ex.Stacktrace.Frames[0]
+	assert.True(t, strings.HasSuffix(fr.Function, methodName), "function name has suffix: " + fr.Function)
+	assert.Equal(t, glogErrorLine, fr.Lineno, "line number matches of the glog invocation")
+	assert.True(t, strings.HasSuffix(fr.AbsPath, fileName), "abspath matches: " + fr.AbsPath)
+
+	ex = e.Exception[1] // second exception is passed from the error argument
+	assert.True(t, strings.HasPrefix(ex.Type, "test message"),
+		"type (primary issue title) starts with the error string: " + ex.Type)
+	assert.True(t, strings.HasPrefix(ex.Value, fmt.Sprintf("%s.%s:%d", pkgName, methodName, errorLine)),
+		"value (issue subtitle) starts with the method name and error line of the yerrors invocation: " + ex.Value)
+	assert.NotNil(t, ex.Stacktrace)
+	assert.Len(t, ex.Stacktrace.Frames, 2, "two stacktrace frames")
+
+	for _, fr := range ex.Stacktrace.Frames {
+		assert.True(t, strings.HasSuffix(fr.Function, methodName), "function name has suffix: " + fr.Function)
+		assert.Equal(t, errorLine, fr.Lineno, "line number matches of the yerrors invocation")
+		assert.True(t, strings.HasSuffix(fr.AbsPath, fileName), "abspath matches: " + fr.AbsPath)
+	}
+}
+
+func TestGlogYerrorsWrappedEvent(t *testing.T) {
+	methodName := "TestGlogYerrorsWrappedEvent" // this should stay in sync with the name of the method
+
+	ready := make(chan interface{})
+	done := make(chan *sentrygo.Event)
+	go setup(ready, done, 1)
+
+	<-ready
+	errorLine := 192 // this should point to the next line
+	err := yerrors.New("test message")
+	errorWrappedLine := errorLine + 2 // this should point to the next line
+	wrap := yerrors.Wrap(err)
+	glogErrorLine := errorWrappedLine + 2 // this should point to the next line
+	glog.Error(wrap)
+	e := <-done
+
+	assert.NotNil(t, e)
+	assert.Equal(t, sentrygo.LevelError, e.Level, "level is error")
+	assert.True(t, strings.HasPrefix(e.Message, "test message"),
+		"message starts with the error string")
+	assert.Len(t, e.Exception, 3, "three exceptions (first is from glog, second two are from err)")
+
+	ex := e.Exception[0] // first exception is from the glog invocation
+	assert.True(t, strings.HasPrefix(ex.Type, "test message"),
+		"type (primary issue title) starts with the error string: " + ex.Type)
+	assert.True(t, strings.HasPrefix(ex.Value, fmt.Sprintf("%s:%d", methodName, glogErrorLine)),
+		"value (issue subtitle) starts with the method name and error line of the glog invocation: " + ex.Value)
+	assert.NotNil(t, ex.Stacktrace)
+	assert.Len(t, ex.Stacktrace.Frames, 1, "one stacktrace frame")
+
+	fr := ex.Stacktrace.Frames[0]
+	assert.True(t, strings.HasSuffix(fr.Function, methodName), "function name has suffix: "+fr.Function)
+	assert.Equal(t, glogErrorLine, fr.Lineno, "line number matches")
+	assert.True(t, strings.HasSuffix(fr.AbsPath, fileName), "abspath matches: " + fr.AbsPath)
+
+	ex = e.Exception[1] // second exception contains the inner frame from the invoked error
+	assert.True(t, strings.HasPrefix(ex.Type, "test message"),
+		"type (primary issue title) starts with the error string: " + ex.Type)
+	assert.True(t, strings.HasPrefix(ex.Value, fmt.Sprintf("%s.%s:%d", pkgName, methodName, errorLine)),
+		"value (issue subtitle) starts with the method name and error line: " + ex.Value)
+	assert.NotNil(t, ex.Stacktrace)
+	assert.Len(t, ex.Stacktrace.Frames, 2, "two stacktrace frames")
+
+	for _, fr := range ex.Stacktrace.Frames {
+		assert.True(t, strings.HasSuffix(fr.Function, methodName), "function name has suffix: "+fr.Function)
+		assert.Equal(t, errorLine, fr.Lineno, "line number matches")
+		assert.True(t, strings.HasSuffix(fr.AbsPath, fileName), "abspath matches: " + fr.AbsPath)
+	}
+
+	ex = e.Exception[2] // third exception contains the outer frame from the called error
+	assert.True(t, strings.HasPrefix(ex.Type, "test message"),
+		"type (primary issue title) starts with the error string: " + ex.Type)
+	assert.True(t, strings.HasPrefix(ex.Value, fmt.Sprintf("%s.%s:%d", pkgName, methodName, errorLine)),
+		"value (issue subtitle) starts with the method name and error line: " + ex.Value)
+	assert.NotNil(t, ex.Stacktrace)
+	assert.Len(t, ex.Stacktrace.Frames, 3, "three stacktrace frames")
+	for _, fr := range ex.Stacktrace.Frames {
+		assert.True(t, strings.HasSuffix(fr.Function, methodName), "function name has suffix: "+fr.Function)
+		assert.True(t, strings.HasSuffix(fr.AbsPath, fileName), "abspath matches: " + fr.AbsPath)
+	}
+	assert.Equal(t, errorWrappedLine, ex.Stacktrace.Frames[0].Lineno, "first frame line number matches")
+	assert.Equal(t, errorWrappedLine, ex.Stacktrace.Frames[1].Lineno, "second frame line number matches")
+	assert.Equal(t, errorLine, ex.Stacktrace.Frames[2].Lineno, "third frame line number matches")
+}

--- a/sentry/formatters.go
+++ b/sentry/formatters.go
@@ -1,0 +1,69 @@
+package sentry
+
+import (
+	"strings"
+
+	"github.com/getsentry/sentry-go"
+	"golang.org/x/xerrors"
+)
+
+// headline returns a good Headline for this error.
+// Ideally, it returns a succinct summary that best conveys the error.
+// Most likely, that's something close to the root cause, but that may
+// be something boring like "context canceled".
+func headline(err error) string {
+	// Heuristic: return the error message from the second innermost error.
+	// This provides context on the error, since returned errors are often constants.
+	var prev error
+	for {
+		wrapper, ok := err.(xerrors.Wrapper)
+		if !ok {
+			break
+		}
+		prev = err
+		err = wrapper.Unwrap()
+	}
+	if prev != nil {
+		return prev.Error()
+	}
+	return err.Error()
+}
+
+
+// removeGlogPrefixFromMessage removes the glog date/level from the
+// raw byte string returned from glogEvent.Message
+func removeGlogPrefixFromMessage(msg []byte) string {
+	message := string(msg)
+	if square := strings.Index(message, "] "); square != -1 {
+		message = message[square+2:]
+	}
+
+	return message
+}
+
+// cleanupMessage cleans up a message displayed as the top-line
+// Sentry error by splitting at the first newline.
+func cleanupMessage(msg string) string {
+	return strings.Split(strings.TrimSpace(msg), "\n")[0]
+}
+
+// prependMessage prepends the given possiblePrefix to an
+// existing fullMsg. If fullMsg starts with possiblePrefix
+// then the prefix is removed. Otherwise the possiblePrefix
+// is shown before the given message.
+func prependMessage(possiblePrefix, fullMsg string) string {
+	trimmedMsg := strings.TrimPrefix(fullMsg, possiblePrefix)
+	trimmedMsg = strings.TrimSpace(trimmedMsg)
+	trimmedMsg = strings.TrimPrefix(trimmedMsg, ":")
+	if len(trimmedMsg) > 0 {
+		return possiblePrefix + "\n" + trimmedMsg
+	} else {
+		return possiblePrefix
+	}
+}
+
+// buildLevel converts a glog level to a sentry level.
+// input level is one of: INFO, WARNING, ERROR or FATAL
+func buildLevel(severity string) sentry.Level {
+	return sentry.Level(strings.ToLower(severity))
+}

--- a/sentry/http.go
+++ b/sentry/http.go
@@ -1,0 +1,48 @@
+package sentry
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// HTTP request building code, used to augment the data sent to Sentry
+// if a http.Request object is passed as an argument to glog.
+
+func buildHttpRequest(r *http.Request) *sentry.Request {
+	return &sentry.Request{
+		URL:         r.URL.String(),
+		Method:      r.Method,
+		Headers:     sentryHeaders(r.Header),
+		Cookies:     r.Header.Get("Cookie"),
+		QueryString: r.URL.RawQuery,
+		Data:        sentryData(r.Body),
+		Env:         nil,
+	}
+}
+
+func sentryHeaders(headers map[string][]string) map[string]string {
+	var m = map[string]string{}
+	for k, v := range headers {
+		// Skip including cookies in the headers.  Cookies have their own section.
+		if k != "Cookie" {
+			m[k] = strings.Join(v, ",")
+		}
+	}
+	return m
+}
+
+func sentryData(body io.ReadCloser) string {
+	if s, ok := body.(io.Seeker); ok {
+		s.Seek(0, 0)
+	}
+	b, err := ioutil.ReadAll(body)
+	if err != nil {
+		return fmt.Sprintf("<%v>", err)
+	}
+	return string(b)
+}

--- a/stacktrace/filesystem.go
+++ b/stacktrace/filesystem.go
@@ -1,0 +1,45 @@
+package stacktrace
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// GopathRelativeFile sanitizes the path to remove GOPATH and obtain the import path.
+// Concretely, this takes the path after the last instance of '/src/'.
+// This may omit some of the path if there is an src directory in a package import path.
+// If there are no /src/ directories in the path, the base filename is returned.
+func GopathRelativeFile(absPath string) string {
+	candidates := strings.SplitAfter(absPath, "/src/")
+	if len(candidates) > 0 {
+		return candidates[len(candidates)-1]
+	}
+	return filepath.Base(absPath)
+}
+
+// GuessAbsPath guesses the proper absolute path if it is not
+// provided, making a best-effort guess so that Sentry can attempt
+// to augment the error with source code
+func GuessAbsPath(f string) string {
+	gopath := os.Getenv("GOPATH")
+	// Break out if the GOPATH can't be identified, or the path
+	// is already an absolute path.
+	if gopath == "" || strings.HasPrefix(f, "/") {
+		return f
+	}
+
+	ignoredPrefixes := []string{gopath, "external/", "GOROOT/", "bazel-"}
+	for _, prefix := range ignoredPrefixes {
+		if strings.HasPrefix(f, prefix) {
+			return f
+		}
+	}
+
+	if strings.HasPrefix(f, filepath.Base(gopath)) {
+		return path.Join(filepath.Dir(gopath), f)
+	} else {
+		return path.Join(gopath, f)
+	}
+}

--- a/stacktrace/filesystem_test.go
+++ b/stacktrace/filesystem_test.go
@@ -1,0 +1,35 @@
+package stacktrace_test
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/yext/glog-contrib/stacktrace"
+)
+
+var gopath string
+var gopathFolderName string
+
+func init() {
+	gopath = os.Getenv("GOPATH")
+	gopathFolderName = filepath.Base(gopath)
+}
+
+func TestGopathRelativeFile(t *testing.T) {
+	assert.Equal(t, "yext/examples/example.go", stacktrace.GopathRelativeFile(path.Join(gopathFolderName, "src/yext/examples/example.go")))
+	assert.Equal(t, "folder/that-is-not-src/examples/example.go", stacktrace.GopathRelativeFile("folder/that-is-not-src/examples/example.go"))
+	assert.Equal(t, "/path/to/folder/that-is-not-src/examples/example.go", stacktrace.GopathRelativeFile("/path/to/folder/that-is-not-src/examples/example.go"))
+}
+
+func TestGuessAbsPath(t *testing.T) {
+	assert.Equal(t, path.Join(gopath, "src/yext/example.go"), stacktrace.GuessAbsPath(path.Join(gopathFolderName, "src/yext/example.go")))
+	assert.Equal(t, "bazel-out/darwin-fastbuild/bin/src/example.go", stacktrace.GuessAbsPath("bazel-out/darwin-fastbuild/bin/src/example.go"))
+	assert.Equal(t, "external/com_github_grpc_ecosystem_go_grpc_middleware/example.go", stacktrace.GuessAbsPath("external/com_github_grpc_ecosystem_go_grpc_middleware/example.go"))
+	assert.Equal(t, "GOROOT/src/runtime/asm_amd64.s", stacktrace.GuessAbsPath("GOROOT/src/runtime/asm_amd64.s"))
+	assert.Equal(t, "/path/to/foo/bar.go", stacktrace.GuessAbsPath("/path/to/foo/bar.go"))
+	assert.Equal(t, path.Join(gopath, "foo/bar.go"), stacktrace.GuessAbsPath(path.Join(gopath, "foo/bar.go")))
+}

--- a/stacktrace/formatters.go
+++ b/stacktrace/formatters.go
@@ -1,0 +1,24 @@
+package stacktrace
+
+import (
+	"fmt"
+
+	"github.com/getsentry/sentry-go"
+)
+
+// SourceFromStack retrieves the function and line where the
+// event was logged from in the format "file.Function:118".
+func SourceFromStack(s *sentry.Stacktrace) string {
+	if s == nil || len(s.Frames) == 0 {
+		return ""
+	}
+
+	f := s.Frames[len(s.Frames)-1]
+	filename := ""
+	if f.Filename != "" {
+		filename = " (" + GopathRelativeFile(f.Filename) + ")"
+	} else if f.AbsPath != "" {
+		filename = " (" + GopathRelativeFile(f.AbsPath) + ")"
+	}
+	return fmt.Sprintf("%s:%d%s", f.Function, f.Lineno, filename)
+}

--- a/stacktrace/stacktrace.go
+++ b/stacktrace/stacktrace.go
@@ -1,72 +1,213 @@
 package stacktrace
 
 import (
-	"fmt"
-	"path/filepath"
+	"reflect"
 	"runtime"
-	"strconv"
 	"strings"
+
+	"github.com/getsentry/sentry-go"
 )
 
-type StackTrace struct {
-	Frames []StackFrame `json:"frames"`
+// The following methods are taken from stacktrace.go in the sentry-go package
+// because non-exported methods are needed to process frames from a glog message
+// without wrapping it in an error (which prevents augmenting with xerrors info).
+//
+// Copyright (c) 2019 Sentry (https://sentry.io) and individual contributors.
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+// ExtractStacktrace creates a new Stacktrace based on the given error.
+func ExtractStacktrace(err error) *sentry.Stacktrace {
+	method := extractReflectedStacktraceMethod(err)
+
+	var pcs []uintptr
+
+	if method.IsValid() {
+		pcs = extractPcs(method)
+	} else {
+		pcs = extractXErrorsPC(err)
+	}
+
+	if len(pcs) == 0 {
+		return nil
+	}
+
+	// PATCH(jwoglom): split out extracting frames to new method
+	return ExtractFrames(pcs, err)
 }
 
-type StackFrame struct {
-	AbsPath  string `json:"abs_path"`
-	Filename string `json:"filename"`
-	Function string `json:"function"`
-	LineNo   string `json:"lineno"`
+// PATCH(jwoglom): ExtractFrames is split-out code from ExtractStacktrace
+// which allows for frame extraction to be performed given glog PC pointers.
+// The err argument is optional, if it is nil augmentation of xerror info is
+// not provided.
+func ExtractFrames(pcs []uintptr, err error) *sentry.Stacktrace {
+	frames := extractFrames(pcs)
+	frames = filterFrames(frames)
+
+	stacktrace := sentry.Stacktrace{
+		Frames: frames,
+	}
+
+	// augment with xerrors stack trace, if available
+	return GetXErrorStackTrace(stacktrace, err)
 }
 
-func Build(stack []uintptr) StackTrace {
-	var ravenStackTrace = make([]StackFrame, 0, len(stack))
-	frames := runtime.CallersFrames(stack)
+// NewFrame assembles a stacktrace frame out of runtime.Frame.
+func NewFrame(f runtime.Frame) sentry.Frame {
+	// PATCH(jwoglom): wrap the exported NewFrame method
+	// with some custom handling
+
+	return fixUpFrame(sentry.NewFrame(f))
+}
+
+// PATCH(jwoglom): fixes up the given frame
+func fixUpFrame(frame sentry.Frame) sentry.Frame {
+	// Without an absolute filesystem path for AbsPath,
+	// Sentry will not pull in neighboring code segments.
+	if frame.AbsPath != "" && !strings.HasPrefix(frame.AbsPath, "/") {
+		frame.AbsPath = GuessAbsPath(frame.AbsPath)
+	} else if frame.AbsPath == "" {
+		frame.AbsPath = GuessAbsPath(frame.Filename)
+	}
+
+	// Clean up the returned filename to remove the gopath
+	frame.Filename = GopathRelativeFile(frame.Filename)
+
+	return frame
+}
+
+func extractFrames(pcs []uintptr) []sentry.Frame {
+	var frames []sentry.Frame
+	callersFrames := runtime.CallersFrames(pcs)
+
 	for {
-		frame, more := frames.Next()
+		callerFrame, more := callersFrames.Next()
 
-		absPath := frame.File
-		file := filepath.Base(absPath)
+		frames = append([]sentry.Frame{
+			NewFrame(callerFrame),
+		}, frames...)
 
-		// Sanitize the path to remove GOPATH and obtain the import path.
-		// Will take the path after the last instance of '/src/'.
-		// This may omit some of the path if there is an src directory in a package import path.
-		candidates := strings.SplitAfter(absPath, "/src/")
-		if len(candidates) > 0 {
-			file = candidates[len(candidates)-1]
-		}
-
-		ravenStackTrace = append(ravenStackTrace, StackFrame{
-			AbsPath:  absPath,
-			Filename: file,
-			Function: frame.Function,
-			LineNo:   strconv.Itoa(frame.Line),
-		})
 		if !more {
 			break
 		}
 	}
-	// Reverse the stack trace to fit with Sentry's expectations.
-	for i, j := 0, len(ravenStackTrace)-1; i < j; i, j = i+1, j-1 {
-		ravenStackTrace[i], ravenStackTrace[j] = ravenStackTrace[j], ravenStackTrace[i]
-	}
 
-	return StackTrace{ravenStackTrace}
+	return frames
 }
 
-// Inner returns the innermost stack frame.
-func (st StackTrace) Inner() StackFrame {
-	if len(st.Frames) == 0 {
-		return StackFrame{}
+// filterFrames filters out stack frames that are not meant to be reported to
+// Sentry. Those are frames internal to the SDK or Go.
+func filterFrames(frames []sentry.Frame) []sentry.Frame {
+	if len(frames) == 0 {
+		return nil
 	}
-	return st.Frames[len(st.Frames)-1]
+
+	filteredFrames := make([]sentry.Frame, 0, len(frames))
+
+	for _, frame := range frames {
+		// Skip Go internal frames.
+		if frame.Module == "runtime" || frame.Module == "testing" {
+			continue
+		}
+		// Skip Sentry internal frames, except for frames in _test packages (for
+		// testing).
+		if strings.HasPrefix(frame.Module, "github.com/getsentry/sentry-go") &&
+			!strings.HasSuffix(frame.Module, "_test") {
+			continue
+		}
+		filteredFrames = append(filteredFrames, frame)
+	}
+
+	return filteredFrames
 }
 
-// Strings returns a list of string descriptions of each stack frame.
-func (st StackTrace) Strings() []string {
-	var r = make([]string, len(st.Frames))
-	for i, f := range st.Frames {
-		r[i] = fmt.Sprintf("%s in %s at line %s", f.Filename, f.Function, f.LineNo)
+func extractReflectedStacktraceMethod(err error) reflect.Value {
+	var method reflect.Value
+
+	// https://github.com/pingcap/errors
+	methodGetStackTracer := reflect.ValueOf(err).MethodByName("GetStackTracer")
+	// https://github.com/pkg/errors
+	methodStackTrace := reflect.ValueOf(err).MethodByName("StackTrace")
+	// https://github.com/go-errors/errors
+	methodStackFrames := reflect.ValueOf(err).MethodByName("StackFrames")
+
+	if methodGetStackTracer.IsValid() {
+		stacktracer := methodGetStackTracer.Call(make([]reflect.Value, 0))[0]
+		stacktracerStackTrace := reflect.ValueOf(stacktracer).MethodByName("StackTrace")
+
+		if stacktracerStackTrace.IsValid() {
+			method = stacktracerStackTrace
+		}
 	}
-	return r
+
+	if methodStackTrace.IsValid() {
+		method = methodStackTrace
+	}
+
+	if methodStackFrames.IsValid() {
+		method = methodStackFrames
+	}
+
+	return method
+}
+
+func extractPcs(method reflect.Value) []uintptr {
+	var pcs []uintptr
+
+	stacktrace := method.Call(make([]reflect.Value, 0))[0]
+
+	if stacktrace.Kind() != reflect.Slice {
+		return nil
+	}
+
+	for i := 0; i < stacktrace.Len(); i++ {
+		pc := stacktrace.Index(i)
+
+		if pc.Kind() == reflect.Uintptr {
+			pcs = append(pcs, uintptr(pc.Uint()))
+			continue
+		}
+
+		if pc.Kind() == reflect.Struct {
+			field := pc.FieldByName("ProgramCounter")
+			if field.IsValid() && field.Kind() == reflect.Uintptr {
+				pcs = append(pcs, uintptr(field.Uint()))
+				continue
+			}
+		}
+	}
+
+	return pcs
+}
+
+// extractXErrorsPC extracts program counters from error values compatible with
+// the error types from golang.org/x/xerrors.
+//
+// It returns nil if err is not compatible with errors from that package or if
+// no program counters are stored in err.
+func extractXErrorsPC(err error) []uintptr {
+	// This implementation uses the reflect package to avoid a hard dependency
+	// on third-party packages.
+
+	// We don't know if err matches the expected type. For simplicity, instead
+	// of trying to account for all possible ways things can go wrong, some
+	// assumptions are made and if they are violated the code will panic. We
+	// recover from any panic and ignore it, returning nil.
+	//nolint: errcheck
+	defer func() { recover() }()
+
+	field := reflect.ValueOf(err).Elem().FieldByName("frame") // type Frame struct{ frames [3]uintptr }
+	field = field.FieldByName("frames")
+	field = field.Slice(1, field.Len()) // drop first pc pointing to xerrors.New
+	pc := make([]uintptr, field.Len())
+	for i := 0; i < field.Len(); i++ {
+		pc[i] = uintptr(field.Index(i).Uint())
+	}
+	return pc
 }

--- a/stacktrace/xerrors.go
+++ b/stacktrace/xerrors.go
@@ -1,0 +1,75 @@
+package stacktrace
+
+import (
+	"golang.org/x/xerrors"
+
+	"github.com/getsentry/sentry-go"
+	"github.com/yext/glog"
+)
+
+// GetXErrorStackTrace returns a combined stack trace incorporating the stack of
+// the logging call site and that of the error it's logging.
+func GetXErrorStackTrace(callSite sentry.Stacktrace, err error) *sentry.Stacktrace {
+	xs := &xerrorsStack{trace: callSite}
+	for err != nil {
+		xs.detail = false
+		switch xerr := err.(type) {
+		case xerrors.Formatter:
+			err = xerr.FormatError(xs)
+		case xerrors.Wrapper:
+			err = xerr.Unwrap()
+		default:
+			err = nil
+		}
+	}
+	return &xs.trace
+}
+
+// xerrorsStack implements xerrors.Printer to capture only the wrapped stack trace.
+//
+// Exploits the fact that xerrors.Frame is always written as detail (and nothing else is, for any
+// known implementation).
+//
+// It expects a sequence of alternating calls like this:
+//
+//   Printf("%s\n    ", []interface {}{"package.FuncName"})
+//   Printf("%s:%d\n", []interface {}{"/absolute/path/to/file.go", 47})
+type xerrorsStack struct {
+	detail bool
+	trace  sentry.Stacktrace
+	fnName string
+}
+
+func (x *xerrorsStack) Print(args ...interface{}) {}
+
+func (x *xerrorsStack) Printf(format string, args ...interface{}) {
+	if x.detail {
+		switch len(args) {
+		case 1:
+			if fn, ok := args[0].(string); ok {
+				x.fnName = fn
+			}
+		case 2:
+			var (
+				absPath, ok1 = args[0].(string)
+				lineno, ok2  = args[1].(int)
+			)
+			if !ok1 || !ok2 {
+				glog.Warningf("unexpected: Printf(%q, %#v)", format, args)
+				return
+			}
+			// fixUpFrame will clean up the Filename/AbsPath
+			x.trace.Frames = append(x.trace.Frames, fixUpFrame(sentry.Frame{
+				AbsPath:  absPath,
+				Filename: absPath,
+				Function: x.fnName,
+				Lineno:   lineno,
+			}))
+		}
+	}
+}
+
+func (x *xerrorsStack) Detail() bool {
+	x.detail = true
+	return true
+}


### PR DESCRIPTION
Adds a sentry subpackage to the project, which interfaces
with Sentry via the sentry-go package instead of using
the legacy go raven client. The old raven subpackage has
been kept in order to more easily facilitate a migration
between the two packages.

In order to migrate use of the legacy raven client,
calls to raven.CaptureErrors and CaptureErrorsAltDsn
should be replaced with the singular sentry.CaptureErrors.
Use of raven.AltDsn and raven.Fingerprint should be
replaced with equivalent use of sentry.AltDsn and
sentry.Fingerprint.

Rewrites the stacktrace module to make use of the
sentry-go package Stacktrace struct. Moves the stacktrace
files used by the raven client to a subdirectory of the
raven folder. In the new sentry subpackage, equivalent
tests exist in the sentry-go package since we are now
piggybacking on their stacktrace building code.

Adds a robust test that verifies the output of the
events sent to Sentry for glog.Error calls, including
differences between passing strings, raw error objects,
or xerror/yerror objects to glog. Also adds a test in
the stacktrace subpackage which verifies paths are
normalized properly.

J=SRE-3390